### PR TITLE
Update OG image handling

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,7 +7,7 @@ import Footer from '../components/Footer.astro';
 import CanonicalUrl from '../components/CanonicalUrl.astro';
 import PersonSchema from '../components/PersonSchema.astro';
 
-interface Props {
+export interface Props {
         title: string;
         description?: string;
         path?: string;
@@ -31,7 +31,7 @@ const criticalCSS = await Astro.slots.render('critical-css');
 <!doctype html>
 <html lang="en">
 	<head>
-  <HtmlHead title={title} description={description} />
+  <HtmlHead title={title} description={description} image={image} />
   <CanonicalUrl path={Astro.url.pathname} />
   <style is:inline>{criticalCSS}</style>
 		<link rel="stylesheet" href="/styles/global.css" media="print" onload="this.media='all'" />

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -44,7 +44,8 @@ const frontmatter = {
     title: article.data.title,
     description: article.data.description,
     date: article.data.date instanceof Date ? article.data.date.toISOString() : article.data.date || '',
-    minutesToRead: typeof article.data.readingTime === 'string' ? parseInt(article.data.readingTime, 10) : article.data.readingTime || 5
+    minutesToRead: typeof article.data.readingTime === 'string' ? parseInt(article.data.readingTime, 10) : article.data.readingTime || 5,
+    image: article.data.image
 };
 ---
 


### PR DESCRIPTION
## Summary
- export `Props` from `Layout.astro` and pass the `image` prop through
- include the article image when building frontmatter

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6842f09bf8c0832aafca8699ce9b50d6