### PR TITLE
Fix Netlify build by disabling API prerender

### DIFF
--- a/src/pages/api/test-convertkit.ts
+++ b/src/pages/api/test-convertkit.ts
@@ -1,5 +1,8 @@
 import type { APIRoute } from 'astro';
 
+// Disable prerendering so this API route isn't executed at build time
+export const prerender = false;
+
 export const GET: APIRoute = async () => {
     try {
         const CONVERTKIT_API_KEY = import.meta.env.CONVERTKIT_API_KEY;


### PR DESCRIPTION
## Summary
- avoid running the ConvertKit test API during build by setting `prerender = false`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684306cdd474832a9d62e37d6795cecd