### PR TITLE
Add automatic OG image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "add-slugs": "tsx scripts/add-slugs.ts"
+    "add-slugs": "tsx scripts/add-slugs.ts",
+    "generate-og-images": "tsx scripts/generate-og-images.ts"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.2.3",

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+import { load } from 'js-yaml';
+import sharp from 'sharp';
+
+const articlesDir = path.join(process.cwd(), 'src/content/articles');
+const outputDir = path.join(process.cwd(), 'public/images/og');
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+function escapeXML(str: string) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+const files = fs.readdirSync(articlesDir).filter(f => f.endsWith('.mdx'));
+
+for (const file of files) {
+  const filePath = path.join(articlesDir, file);
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const [, frontmatter] = content.split('---');
+  if (!frontmatter) continue;
+  let data: any = {};
+  try {
+    data = load(frontmatter.trim());
+  } catch (e) {
+    console.error('Failed to parse frontmatter of', file);
+    continue;
+  }
+  const title: string = data.title || 'Untitled';
+  const slug: string = data.slug || (
+    (data.date ? (new Date(data.date).toISOString().split('T')[0]) : '') + '-' +
+    title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+  );
+  const url = `https://www.antonsten.com/articles/${slug}/`;
+
+  const svg = `<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  <style>
+    .title { font-family: Helvetica, Arial, sans-serif; font-size: 64px; font-weight: bold; fill: #000; }
+    .url { font-family: Helvetica, Arial, sans-serif; font-size: 32px; fill: #000; }
+  </style>
+  <text x="50%" y="45%" text-anchor="middle" class="title">${escapeXML(title)}</text>
+  <text x="50%" y="80%" text-anchor="middle" class="url">${escapeXML(url)}</text>
+</svg>`;
+
+  const svgBuffer = Buffer.from(svg);
+  const outputPath = path.join(outputDir, `${slug}.png`);
+  await sharp(svgBuffer).png().toFile(outputPath);
+  console.log('Generated', outputPath);
+}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -30,8 +30,14 @@ const {
     date = '',
     minutesToRead = 5,
     keywords = [],
-    image = '/images/og-image.png'
+    image: frontImage
 } = Astro.props.frontmatter || Astro.props;
+
+const slugFromPath = Astro.url.pathname
+  .replace(/^\/articles\//, '')
+  .replace(/\/$/, '');
+const defaultOgImage = `/images/og/${slugFromPath}.png`;
+const ogImage = frontImage || defaultOgImage;
 
 const formattedDate = formatDate(date);
 const path = Astro.url.pathname;
@@ -47,13 +53,13 @@ const url = Astro.url.toString();
         title={`${title} | Anton Sten`}
         description={description}
         path={path}
-        image={image}
+        image={ogImage}
 >
     <ArticleSchema
         title={title}
         description={description}
         publishDate={new Date(date)}
-        image={`https://www.antonsten.com${image}`}
+        image={`https://www.antonsten.com${ogImage}`}
         url={url}
         readingTime={minutesToRead}
         keywords={keywords}


### PR DESCRIPTION
## Summary
- generate OG images for posts via `generate-og-images` script
- default blog post layout to use per-article OG image
- add npm script for OG image generation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68430cd74eac832a852f2666c2292a7d