### PR TITLE
Fix OG image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "add-slugs": "tsx scripts/add-slugs.ts",
-    "generate-og-images": "tsx scripts/generate-og-images.ts"
+    "generate-og-images": "tsx scripts/generate-og-images.ts",
+    "prebuild": "npm run generate-og-images"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.2.3",

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -34,11 +34,14 @@ for (const file of files) {
     continue;
   }
   const title: string = data.title || 'Untitled';
-  const slug: string = data.slug || (
-    (data.date ? (new Date(data.date).toISOString().split('T')[0]) : '') + '-' +
-    title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
-  );
-  const url = `https://www.antonsten.com/articles/${slug}/`;
+  const slug = data.slug;
+  const slugFromFile = file.replace(/\.mdx$/, '');
+
+  if (slug && slug !== slugFromFile) {
+    console.warn(`Slug mismatch in ${file}: frontmatter slug \"${slug}\" does not match filename.`);
+  }
+
+  const url = `https://www.antonsten.com/articles/${slugFromFile}/`;
 
   const svg = `<svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
   <rect width="100%" height="100%" fill="#ffffff"/>
@@ -51,7 +54,7 @@ for (const file of files) {
 </svg>`;
 
   const svgBuffer = Buffer.from(svg);
-  const outputPath = path.join(outputDir, `${slug}.png`);
+  const outputPath = path.join(outputDir, `${slugFromFile}.png`);
   await sharp(svgBuffer).png().toFile(outputPath);
   console.log('Generated', outputPath);
 }


### PR DESCRIPTION
## Summary
- update OG image generation script to use filename for slug
- log slug mismatches
- add `prebuild` npm script to run OG image generation

## Testing
- `npm run generate-og-images`
- `timeout 40 npm run build` (cancelled after verifying prebuild step)

------
https://chatgpt.com/codex/tasks/task_e_68431686de84832aa2b60b034b2503a2